### PR TITLE
Refactor TreeNode render method

### DIFF
--- a/src/TreeNode.jsx
+++ b/src/TreeNode.jsx
@@ -55,15 +55,13 @@ var TreeNode = React.createClass({
       collapseIconClass: ""
     }
   },
-
-  render : function () {
-
+  
+  _getCollapseNode: function() {
     var props = this.props,
-      collapseNode = null,
-      rootClass = this._getRootCssClass();
+      collapseNode = null;
 
     if (props.collapsible) {
-      var collapseClassName = rootClass + "-collapse-toggle ";
+      var collapseClassName = this._getRootCssClass() + "-collapse-toggle ";
       var collapseToggleHandler = this._handleCollapseChange;
       if (!props.children || props.children.length === 0) {
         collapseToggleHandler = noop;
@@ -73,17 +71,20 @@ var TreeNode = React.createClass({
       }
       collapseNode = <span onClick={collapseToggleHandler} className={collapseClassName}></span>
     }
+    return collapseNode;
+  },
 
+  render : function () {
     return (
-      <div className={rootClass}>
-        {collapseNode}
+      <div className={this._getRootCssClass()}>
+        {this._getCollapseNode()}
         <span onClick={this._handleClick}>
           {this._getCheckboxNode()}
           {this._getLabelNode()}
         </span>
         {this._getChildrenNode()}
-      </div>);
-
+      </div>
+    );
   },
 
   componentWillReceiveProps: function (nextProps) {

--- a/src/TreeNode.jsx
+++ b/src/TreeNode.jsx
@@ -77,7 +77,10 @@ var TreeNode = React.createClass({
     return (
       <div className={rootClass}>
         {collapseNode}
-        {this._getLabelNode()}
+        <span onClick={this._handleClick}>
+          {this._getCheckboxNode()}
+          {this._getLabelNode()}
+        </span>
         {this._getChildrenNode()}
       </div>);
 
@@ -141,14 +144,7 @@ var TreeNode = React.createClass({
 
     if (props.labelFilter) displayLabel = props.labelFilter(displayLabel);
 
-    var labelNode = <label className={labelClassName}>{displayLabel}</label>;
-
-    return (
-      <span onClick={this._handleClick}>
-        {this._getCheckboxNode()}
-        {labelNode}
-      </span>
-    );
+    return <label className={labelClassName}>{displayLabel}</label>;
   },
 
   _getCheckboxNode: function () {


### PR DESCRIPTION
Not a major change but I just wanted to clean up the render method because I am overriding it in my application because I want to have more than just text for my label (an icon next to the label). I was going to allow input of not just a string to the label but a component which I might do some other time but for now this is a good workaround and cleans up the code a bit too.
